### PR TITLE
6 - fix raising exceptions

### DIFF
--- a/EasyCommand.AspNetCore.Tests/Commands/ExceptionCommand.cs
+++ b/EasyCommand.AspNetCore.Tests/Commands/ExceptionCommand.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace EasyCommand.AspNetCore.Tests.Commands
+{
+    class ExceptionCommand : AsyncAspCommandNoRequestNoResult
+    {
+        protected override Task<EmptyCommandResult> ExecuteCommandAsync(EmptyCommandRequest request)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/EasyCommand.AspNetCore.Tests/Handler/FailAfterCommandHandler.cs
+++ b/EasyCommand.AspNetCore.Tests/Handler/FailAfterCommandHandler.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace EasyCommand.AspNetCore.Tests.Handler
+{
+    class FailAfterCommandHandler : IAsyncAspCommandHandler
+    {
+        public Task AfterExecutionAsync<TResponse>(Type command, TResponse response)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task BeforeExecutionAsync<TRequest>(Type command, TRequest request)
+        {
+            return Task.CompletedTask;
+        }
+
+    }
+}

--- a/EasyCommand.AspNetCore.Tests/Handler/FailBeforeCommandHandler.cs
+++ b/EasyCommand.AspNetCore.Tests/Handler/FailBeforeCommandHandler.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace EasyCommand.AspNetCore.Tests.Handler
+{
+    class FailBeforeCommandHandler : IAsyncAspCommandHandler
+    {
+        public Task AfterExecutionAsync<TResponse>(Type command, TResponse response)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task BeforeExecutionAsync<TRequest>(Type command, TRequest request)
+        {
+            throw new NotImplementedException();
+        }
+
+    }
+    
+}

--- a/EasyCommand.AspNetCore/ControllerBaseExtensions.cs
+++ b/EasyCommand.AspNetCore/ControllerBaseExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using EasyCommand.AspNetCore.Exceptions;
 
 namespace EasyCommand.AspNetCore
 {
@@ -60,12 +61,12 @@ namespace EasyCommand.AspNetCore
             {
                 result = await command.ExecuteExternalAsync(request);
             }
-            catch (Exception e)
+            catch
             {
                 var message = $"Failed to run  Execute on {handlers[handlerIndex].GetType()}";
                 await RunHandlersAfterMethods
                           (handlers, commandType, result, handlerIndex, message);
-                throw new Exception(message, e);
+                throw;
             }
             finally
             {
@@ -100,13 +101,14 @@ namespace EasyCommand.AspNetCore
                 }
                 catch (Exception e)
                 {
-                    var message = $"Failed to run  BeforeExecutionAsync on {handlers[i].GetType()}";
+                    var message = $"Failed to run aBeforeExecutionAsync on {handlers[i].GetType()}";
 
                     var result = default(TResult);
 
                     await RunHandlersAfterMethods
                            (handlers, command, result, handlerIndex, message);
-                    throw new Exception(message, e);
+
+                    throw HandlerExecutionException.CreateWhenFailedBeforeCommandExecution(command, handlers[i].GetType(),e);
                 }
             }
         }
@@ -124,7 +126,7 @@ namespace EasyCommand.AspNetCore
                 }
                 catch (Exception e)
                 {
-                    throw new Exception($"Unable to execute AfterExecutionAsync on {handlers[i].GetType()} {(hasAdditionalInformation ? $"after {additionalFailureInformation}" : null)}", e);
+                    throw HandlerExecutionException.CreateWhenFailedAfterCommandExecution(command, handlers[i].GetType(), e);
                 }
             }
         }

--- a/EasyCommand.AspNetCore/Exceptions/HandlerExecutionException.cs
+++ b/EasyCommand.AspNetCore/Exceptions/HandlerExecutionException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace EasyCommand.AspNetCore.Exceptions
+{
+    public class HandlerExecutionException : Exception
+    {
+        private static String message = "Failed to execute handler {0} running command ({1}). Failure occured when trying to run {2}, Please see inner exception for more details";
+        public HandlerExecutionException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public static HandlerExecutionException CreateWhenFailedBeforeCommandExecution(
+            Type commandType, Type handlerType, Exception innerException)
+        {
+            return CreateWhenFailedCommandExecution("before", commandType, handlerType, innerException);
+        }
+
+        public static HandlerExecutionException CreateWhenFailedAfterCommandExecution(
+            Type commandType, Type handlerType, Exception innerException)
+        {
+            return CreateWhenFailedCommandExecution("after", commandType, handlerType, innerException);
+        }
+        private static HandlerExecutionException CreateWhenFailedCommandExecution(
+         string occurance, Type commandType, Type handlerType, Exception innerException)
+        {
+            return new HandlerExecutionException(
+               string.Format(message, occurance, commandType.Name, handlerType.Name), innerException);
+        }
+    }
+}


### PR DESCRIPTION
Fix for #6, 
Current problems are that the handlers are not raising the correct exceptions and hiding the exception from the command if the command throws. We should instead rethrow the command exception so that end users can catch the exception that they expect

Fixed:
* Rethrowing command exception
* Correct the handlers exceptions and formalise into a custom exception type